### PR TITLE
feature: add more arguments to draft release

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -7,6 +7,16 @@ on:
         description: 'The new version in major.minor.patch format.'
         required: true
         type: string
+      build:
+        description: 'Build the projet with cargo, useful when Cargo.lock is commited and needs to be updated.'
+        required: false
+        default: false
+        type: boolean
+      check_publish:
+        description: 'Dry run cargo publish before pushing changes, useful to not allow unpublishable releases.'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   draft-new-release:
@@ -30,10 +40,24 @@ jobs:
           version: ${{ github.event.inputs.version }}
           manifest: Cargo.toml
 
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
+            default: true
+            override: true
+
+      - name: Cargo build update lockfile
+        if: ${{ inputs.build }}
+        run: cargo build
+
       - name: Format CHANGELOG
         run: |
           curl -fsSL https://dprint.dev/install.sh | sh
           /home/runner/.dprint/bin/dprint fmt CHANGELOG.md
+
+      - name: Publish dry run
+        if: ${{ inputs.check_publish }}
+        run: cargo publish --dry-run --allow-dirty
 
       - name: Add, Commit & Push
         id: make-commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New input `build` for `draft-new-release.yml` to build the crate before add & commit the files, allows lockfile update
+- New input `check_publish` for `draft-new-release.yml` to dry run the cargo publish before add & commit the files, allows to not open a PR on unpublishable state.
+
 ### Changed
 
 - Update DPrint plugins


### PR DESCRIPTION
 - New input `build` for `draft-new-release.yml` to build the crate before add & commit the files, allows lockfile update
- New input `check_publish` for `draft-new-release.yml` to dry run the cargo publish before add & commit the files, allows to not open a PR on unpublishable state.