### PR TITLE
feat: add base_branch input in draft release

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -17,6 +17,11 @@ on:
         required: false
         default: false
         type: boolean
+      base_branch:
+        description: 'Defines the base branch to use to create the pull request against. Default to main.'
+        required: false
+        default: 'main'
+        type: string
 
 jobs:
   draft-new-release:
@@ -74,7 +79,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           head: release/${{ github.event.inputs.version }}
-          base: main
+          base: ${{ inputs.base_branch }}
           title: Release version ${{ github.event.inputs.version }}
           body: |
             Hi @${{ github.actor }}!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `base_branch` input in `draft-new-release.yml` to change the default branch 'main'
+
 ## [2.0.1] - 2022-06-27
 
 ### Fixed


### PR DESCRIPTION
Allows to change the branch against the pull request is created. Default remains 'main'.